### PR TITLE
Add platform_packages to platformio.ini

### DIFF
--- a/CCLoader/platformio.ini
+++ b/CCLoader/platformio.ini
@@ -22,6 +22,7 @@ board                     = esp01_1m
 board_build.flash_mode    = dout
 
 platform                  = ${core_active.platform}
+platform_packages         =
 build_flags               = ${core_active.build_flags}
 
 


### PR DESCRIPTION
platformio.ini complained the "platform_packages" section was missing. Adding it fixed the issue, and I was able to compile.